### PR TITLE
fix: eventBridgeMessage handler to pass details object

### DIFF
--- a/packages/sls-aws/src/eventbridge/__tests__/json-eventbridge-message.test.ts
+++ b/packages/sls-aws/src/eventbridge/__tests__/json-eventbridge-message.test.ts
@@ -1,17 +1,9 @@
 import type { Context, EventBridgeEvent } from 'aws-lambda'
 import { jsonEventBridgeMessage } from '../json-eventbridge-message'
-import { PayloadParseError } from '../../error/parse'
 
 describe('jsonEventBridgeMessage', () => {
-  it('throws a PayloadParseError if parsing ', () => {
-    const event = ({} as unknown) as EventBridgeEvent<string, never>
-    expect(() => jsonEventBridgeMessage(event, {} as Context)).toThrow(
-      new PayloadParseError('failed to process eventbridge message to json', { originalError: expect.any(Error) })
-    )
-  })
-
   it('returns the json parsed detail from the eventbridge event', () => {
-    const event = ({ detail: '{"data":true}' } as unknown) as EventBridgeEvent<string, never>
+    const event = ({ detail: { data: true } } as unknown) as EventBridgeEvent<string, never>
     expect(jsonEventBridgeMessage(event, {} as Context)).toEqual({ data: true })
   })
 })

--- a/packages/sls-aws/src/eventbridge/index.ts
+++ b/packages/sls-aws/src/eventbridge/index.ts
@@ -5,7 +5,7 @@ import { jsonEventBridgeEvent } from './json-eventbridge-event'
 import { jsonEventBridgeMessage } from './json-eventbridge-message'
 
 export type EventBridgeEventHandler = Handler<EventBridgeEvent<string, never>, Context, Promise<void>>
-export type EventBridgeMessageHandler = Handler<EventBridgeEvent<string, string>, Context, Promise<void>>
+export type EventBridgeMessageHandler = Handler<EventBridgeEvent<string, any>, Context, Promise<void>>
 
 export const eventBridgeEvent = <D, P extends EventBridgeEvent<string, any>, C = never>(
   config?: EnvironmentConfig<EventBridgeEventHandler>

--- a/packages/sls-aws/src/eventbridge/index.ts
+++ b/packages/sls-aws/src/eventbridge/index.ts
@@ -4,15 +4,17 @@ import { response } from '../reponse/response-or-error'
 import { jsonEventBridgeEvent } from './json-eventbridge-event'
 import { jsonEventBridgeMessage } from './json-eventbridge-message'
 
-export type EventBridgeEventHandler = Handler<EventBridgeEvent<string, never>, Context, Promise<void>>
-export type EventBridgeMessageHandler = Handler<EventBridgeEvent<string, any>, Context, Promise<void>>
+export type EventBridgeEventHandler<T = never> = Handler<EventBridgeEvent<string, T>, Context, Promise<void>>
+export type EventBridgeMessageHandler<T = never> = Handler<EventBridgeEvent<string, T>, Context, Promise<void>>
 
 export const eventBridgeEvent = <D, P extends EventBridgeEvent<string, any>, C = never>(
-  config?: EnvironmentConfig<EventBridgeEventHandler>
-): SlsEnvironment<EventBridgeEventHandler, C, D, P> =>
-  environment<EventBridgeEventHandler, C, D, P>(config).payload(jsonEventBridgeEvent).successHandler(response)
+  config?: EnvironmentConfig<EventBridgeEventHandler<never>>
+): SlsEnvironment<EventBridgeEventHandler<never>, C, D, P> =>
+  environment<EventBridgeEventHandler<never>, C, D, P>(config).payload(jsonEventBridgeEvent).successHandler(response)
 
 export const eventBridgeMessage = <D, P, C = never>(
-  config?: EnvironmentConfig<EventBridgeMessageHandler>
-): SlsEnvironment<EventBridgeMessageHandler, C, D, P> =>
-  environment<EventBridgeMessageHandler, C, D, P>(config).payload(jsonEventBridgeMessage).successHandler(response)
+  config?: EnvironmentConfig<EventBridgeMessageHandler<never>>
+): SlsEnvironment<EventBridgeMessageHandler<never>, C, D, P> =>
+  environment<EventBridgeMessageHandler<never>, C, D, P>(config)
+    .payload(jsonEventBridgeMessage)
+    .successHandler(response)

--- a/packages/sls-aws/src/eventbridge/json-eventbridge-message.ts
+++ b/packages/sls-aws/src/eventbridge/json-eventbridge-message.ts
@@ -1,6 +1,5 @@
 import type { Context, EventBridgeEvent } from 'aws-lambda'
 
-const jsonEventBridgeMessage = <T>(event: EventBridgeEvent<string, any>, _context: Context): T =>
-  (event.detail as unknown) as T
+const jsonEventBridgeMessage = <T>(event: EventBridgeEvent<string, T>, _context: Context): T => event.detail
 
 export { jsonEventBridgeMessage }

--- a/packages/sls-aws/src/eventbridge/json-eventbridge-message.ts
+++ b/packages/sls-aws/src/eventbridge/json-eventbridge-message.ts
@@ -1,13 +1,6 @@
 import type { Context, EventBridgeEvent } from 'aws-lambda'
 
-import { PayloadParseError } from '../error/parse'
-
-const jsonEventBridgeMessage = <T>(event: EventBridgeEvent<string, string>, _context: Context): T => {
-  try {
-    return (JSON.parse(event.detail) as unknown) as T
-  } catch (err) {
-    throw new PayloadParseError('failed to process eventbridge message to json', { originalError: err })
-  }
-}
+const jsonEventBridgeMessage = <T>(event: EventBridgeEvent<string, any>, _context: Context): T =>
+  (event.detail as unknown) as T
 
 export { jsonEventBridgeMessage }

--- a/yarn.lock
+++ b/yarn.lock
@@ -482,7 +482,7 @@
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
 "@cabiri-io/sls-env@file:packages/sls-env":
-  version "0.12.0"
+  version "0.13.0"
   dependencies:
     "@types/pino" "^6.3.5"
 
@@ -7667,9 +7667,9 @@ tr46@^2.1.0:
     punycode "^2.1.1"
 
 trim-newlines@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"
-  integrity sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
+  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
 
 trim-off-newlines@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
### Description
- Pass event bridge `detail` object as payload rather than attempting to parse