### PR TITLE
fix: set logger initialised variable

### DIFF
--- a/packages/sls-env/src/index.ts
+++ b/packages/sls-env/src/index.ts
@@ -206,14 +206,15 @@ const environment = <H extends Handler<any, any, any>, C, D, P = HandlerPayload<
           .then(() => {
             if (!isLoggerInitialised) {
               applicationLogger = createLogger(logLevel)(applicationLoggerConstructor)
-
-              if (isLogMutable) {
-                applicationLogger = createMutableLogger(applicationLogger)
-              }
-
-              isLoggerInitialised = true
             }
 
+            if (isLogMutable) {
+              const mutableLogger = createMutableLogger(applicationLogger)
+
+              return { logger: mutableLogger }
+            }
+
+            isLoggerInitialised = true
             return { logger: applicationLogger }
           })
           // register invocation context

--- a/packages/sls-env/src/index.ts
+++ b/packages/sls-env/src/index.ts
@@ -206,12 +206,12 @@ const environment = <H extends Handler<any, any, any>, C, D, P = HandlerPayload<
           .then(() => {
             if (!isLoggerInitialised) {
               applicationLogger = createLogger(logLevel)(applicationLoggerConstructor)
-            }
 
-            if (isLogMutable) {
-              const mutableLogger = createMutableLogger(applicationLogger)
+              if (isLogMutable) {
+                applicationLogger = createMutableLogger(applicationLogger)
+              }
 
-              return { logger: mutableLogger }
+              isLoggerInitialised = true
             }
 
             return { logger: applicationLogger }


### PR DESCRIPTION
### Description
- Set the `isLoggerInitialised` variable 
- If `isLogMutable` is true, set `applicationLogger` as the mutable logger