### PR TITLE
fix: set isLoggerInitialised and set mutable logger

### DIFF
--- a/packages/sls-env/src/index.ts
+++ b/packages/sls-env/src/index.ts
@@ -67,7 +67,6 @@ const environment = <H extends Handler<any, any, any>, C, D, P = HandlerPayload<
   const logLevel = logger.level ?? 'info'
   const isLogMutable = logger?.mutable ?? true
   const logInvocationContext = logger?.invocationContext ?? defaultInvodationContext
-  let isLoggerInitialised = false
 
   // ------------------------------------
   // init defaults
@@ -204,14 +203,12 @@ const environment = <H extends Handler<any, any, any>, C, D, P = HandlerPayload<
         Promise.resolve()
           // initialise logger
           .then(() => {
-            if (!isLoggerInitialised) {
+            if (!applicationLogger) {
               applicationLogger = createLogger(logLevel)(applicationLoggerConstructor)
 
               if (isLogMutable) {
                 applicationLogger = createMutableLogger(applicationLogger)
               }
-
-              isLoggerInitialised = true
             }
 
             return { logger: applicationLogger }

--- a/packages/sls-env/src/index.ts
+++ b/packages/sls-env/src/index.ts
@@ -206,12 +206,12 @@ const environment = <H extends Handler<any, any, any>, C, D, P = HandlerPayload<
           .then(() => {
             if (!isLoggerInitialised) {
               applicationLogger = createLogger(logLevel)(applicationLoggerConstructor)
-            }
 
-            if (isLogMutable) {
-              const mutableLogger = createMutableLogger(applicationLogger)
+              if (isLogMutable) {
+                applicationLogger = createMutableLogger(applicationLogger)
+              }
 
-              return { logger: mutableLogger }
+              isLoggerInitialised = true
             }
 
             return { logger: applicationLogger }


### PR DESCRIPTION
### Description
- If logger has already been initialise, do not create a new one
- If `isLogMutable` is true, set `applicationLogger` as the mutable logger

### Summary
This fixes an issue where loggers passed into clients generated within the `global` dependency function will continuously use `child()` parameter from the first invocation.